### PR TITLE
box-shadow added to menu-box class

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -248,6 +248,7 @@ aside h4{
 	padding:20px;
 	background:#282E34;
 	border-radius: 3px;
+	box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.15);
 }
 .menu-box ul{
 	margin:0;


### PR DESCRIPTION
Adicionei um box-shadow suave para facilitar a visualização do menu-box quando ele fica acima do rodapé, que possuem a mesma cor